### PR TITLE
Add laz file extension to read() method

### DIFF
--- a/pclpy/io/functions.py
+++ b/pclpy/io/functions.py
@@ -8,7 +8,7 @@ def read(path: str, point_type: str, xyz_offset=None):
     Read a point cloud by guessing the filetype from its extension.
     """
     extension = os.path.splitext(path)[1][1:].lower()
-    if extension == "las":
+    if extension == "las" or extension == "laz":
         return las.read(path=path, point_type=point_type, xyz_offset=xyz_offset)
 
     raise ValueError("Can't guess filetype from extension ('%s')" % extension)


### PR DESCRIPTION
LAZ is pretty much the standard for LAS file compression, and laspy supports reading .laz files in addition to .las files. Using laspy to read .laz files does require laszip-cli.exe or laszip.exe. If neither of those are present on the users system laspy will throw the following error when trying to read a .laz file:  "laspy.util.LaspyException: Laszip was not found on the system"