### PR TITLE
Fix qhull dependency issue

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - inflection
     - unidecode
     - ply
+    - qhull=2019.1 # exact version needed for pcl 1.9.1
     # - https://github.com/davidcaron/CppHeaderParser/archive/master.zip
   run:
     - python {{ python }}


### PR DESCRIPTION
PCL 1.9.1 only works with [qhull](https://anaconda.org/conda-forge/qhull) 2019.1 and not with the latest 2020.2 selected by default on conda-forge. Added the pinned version to meta.yaml.

Was getting
```
ImportError: libqhull_p.so.7: cannot open shared object file: No such file or directory
```
otherwise when installing with
```
conda install -c conda-forge -c davidcaron pclpy
```

This should really be fixed in https://github.com/conda-forge/pcl-feedstock/blob/master/recipe/meta.yaml but they have already moved to PCL 1.11, so I don't know if it's applicable there anymore.